### PR TITLE
Improvements: Directory Creation and Absolute Path Usage

### DIFF
--- a/module/move/willbe/src/endpoint/workflow.rs
+++ b/module/move/willbe/src/endpoint/workflow.rs
@@ -158,6 +158,16 @@ mod private
   /// Create and write or rewrite content in file.
   pub fn file_write( filename: &Path, content: &str ) -> Result< () > 
   {
+    if let Some( folder ) = filename.parent()
+    {
+      match std::fs::create_dir_all( folder )
+      {
+        Ok( _ ) => {},
+        Err( e ) if e.kind() == std::io::ErrorKind::AlreadyExists => {},
+        Err( e ) => return Err( e.into() ),
+      }
+    }
+
     let mut file = File::create( filename )?;
     file.write_all( content.as_bytes() )?;
     Ok( () )

--- a/module/move/willbe/tests/inc/publish_need.rs
+++ b/module/move/willbe/tests/inc/publish_need.rs
@@ -38,7 +38,8 @@ fn with_changes()
   let temp = assert_fs::TempDir::new().unwrap();
   temp.copy_from( &package_path, &[ "**" ] ).unwrap();
 
-  let mut manifest = manifest::open( temp.as_ref() ).unwrap();
+  let absolute = AbsolutePath::try_from( temp.as_ref() ).unwrap();
+  let mut manifest = manifest::open( absolute ).unwrap();
   version::bump( &mut manifest, false ).unwrap();
 
   _ = cargo::package( &temp, false ).expect( "Failed to package a package" );


### PR DESCRIPTION
## Summary

This pull request includes two main improvements:

1. Improved the `file_write` method in the `workflow.rs` module to check and create the parent directory if it does not exist.
2. Updated the `publish_need.rs` test to use an absolute path when opening the manifest file.

## Details

Improved Directory Check in `file_write` Method: 
- The `file_write` method now checks if the parent directory of a given filename exists before attempting to write the file. 
- If the directory does not exist, it attempts to create it. 
- This change prevents potential failures when writing a file due to a non-existing directory. 

Use of Absolute Path in `publish_need.rs` Test: 
- The `publish_need.rs` test now uses an absolute path when opening the manifest file. 
- This is achieved by leveraging `AbsolutePath::try_from`.
- This change increases the robustness of the code and reduces errors that could stem from the use of relative paths. 
