### PR TITLE
Refactor error handling and update readme

### DIFF
--- a/module/move/willbe/Readme.md
+++ b/module/move/willbe/Readme.md
@@ -7,15 +7,26 @@ Utility to publish multi-crate and multi-workspace environments and maintain the
 
 ### Basic use-case
 
-<!-- qqq : for Bohdan : write good readme -->
+1. **Multi-Workspace Consistency**: In a project setup involving multiple workspaces with shared dependencies, `willbe` maintains consistency. It ensures all workspaces are updated with compatible dependency versions.
+
+2. **Publishing Multi-Crate Projects**: If your project structure includes multiple crates that need simultaneous publishing, `willbe` manages the process seamlessly. It ensures the crates are published in the right order while staying in version sync.
+
+3. **Dependency Analysis**: `willbe` can perform a thorough analysis of your project's dependencies, providing a detailed highlight of inconsistencies or areas that need attention.
+
+4. **Test Execution With Varied Configurations**: `willbe` can execute tests with varying configurations, such as different combinations of crate features. This assists in ensuring comprehensive coverage of test scenarios.
+
+5. **Generate Health Table**: Quickly visualize important project metrics like build status for each crate, creating a single, easy-to-read table.
+
+6. **Automating CI/CD Workflow Generation**: Automatically generate a series of CI/CD operations suitable for the task at hand to enhance productivity and improve the development process.
 
 <!-- {{# generate.module_sample{} #}} -->
 
 ```rust
 use willbe::*;
 
-fn main()
+fn main() -> Result< (), wtools::error::for_app::Error >
 {
+  Ok( willbe::run()? )
 }
 ```
 
@@ -30,6 +41,5 @@ cargo add willbe
 ``` shell test
 git clone https://github.com/Wandalen/wTools
 cd wTools
-cd examples/willbe_trivial_sample
-cargo run
+cargo run --package willbe
 ```

--- a/module/move/willbe/src/tools/graph.rs
+++ b/module/move/willbe/src/tools/graph.rs
@@ -91,6 +91,8 @@ pub( crate ) mod private
         .collect::< Vec< _ > >()
       ),
       Err( index ) => Err( GraphError::Cycle( ( *graph.index( index.node_id() ) ).clone() ) ),
+      // qqq : for Bohdan : bad, make proper error handling
+      // aaa : now returns `GraphError`
     }
   }
 }

--- a/module/move/willbe/src/version.rs
+++ b/module/move/willbe/src/version.rs
@@ -11,7 +11,7 @@ mod private
   use toml_edit::value;
   use semver::Version as SemVersion;
 
-  use wtools::error::for_app::{ Result, anyhow };
+  use wtools::error::for_app::Result;
   use manifest::Manifest;
 
   /// Wrapper for a SemVer structure
@@ -100,7 +100,7 @@ mod private
   /// # Returns:
   /// - `Ok` - the new version number as a string;
   /// - `Err` - if the manifest file cannot be read, written, parsed.
-  pub fn bump( manifest : &mut Manifest, dry : bool ) -> Result< BumpReport >
+  pub fn bump( manifest : &mut Manifest, dry : bool ) -> Result< BumpReport, ManifestError >
   {
     let mut report = BumpReport::default();
 
@@ -115,20 +115,21 @@ mod private
       {
         // qqq : for Bohdan : rid off untyped errors, make proper errors handing
         // https://www.lpalmieri.com/posts/error-handling-rust/
-        return Err( anyhow!( "`{}` - not a package", manifest.manifest_path().as_ref().display() ) );
+        // aaa : used `ManifestError` instead of anyhow.
+        return Err( ManifestError::NotAPackage );
       }
       let package = data.get( "package" ).unwrap();
 
       let version = package.get( "version" );
       if version.is_none()
       {
-        return Err( anyhow!( "`{}` - can not read the version", manifest.manifest_path().as_ref().display() ) );
+        return Err( ManifestError::CannotFindValue( "version".into() ) );
       }
       let version = version.unwrap().as_str().unwrap();
       report.name = Some( package[ "name" ].as_str().unwrap().to_string() );
       report.old_version = Some( version.to_string() );
 
-      Version::from_str( version )?
+      Version::from_str( version ).map_err( | e | ManifestError::InvalidValue( e.to_string() ) )?
     };
 
     let new_version = version.bump().to_string();

--- a/module/move/willbe/tests/inc/endpoints/workflow.rs
+++ b/module/move/willbe/tests/inc/endpoints/workflow.rs
@@ -59,6 +59,7 @@ mod workflow_generate
   
   // qqq for Petro: this test does not work
   // error: called `Result::unwrap()` on an `Err` value: No such file or directory (os error 2)
+  // aaa : It is working now
   #[ test ]
   fn default_case()
   {

--- a/module/move/willbe/tests/inc/publish_need.rs
+++ b/module/move/willbe/tests/inc/publish_need.rs
@@ -1,20 +1,29 @@
 use super::*;
 
-const TEST_MODULE_PATH : &str = "../../test/";
+use std::path::{ Path, PathBuf };
+
 use assert_fs::prelude::*;
 use TheModule::{ manifest, version, cargo };
 use TheModule::package::protected::publish_need;
 use TheModule::package::Package;
 use TheModule::path::AbsolutePath;
 
+const TEST_MODULE_PATH : &str = "../../test/";
+
+fn package_path< P : AsRef< Path > >( path : P ) -> PathBuf
+{
+  let root_path = Path::new( env!( "CARGO_MANIFEST_DIR" ) ).join( TEST_MODULE_PATH );
+  root_path.join( path )
+}
+
 // published the same as local
 #[ test ]
 fn no_changes()
 {
   // Arrange
-  let root_path = std::path::Path::new( env!( "CARGO_MANIFEST_DIR" ) ).join( TEST_MODULE_PATH );
-  let package_path = root_path.join( "c" );
   // qqq : for Bohdan : make helper function returning package_path. reuse it for all relevant tests
+  // aaa : use `package_path` function
+  let package_path = package_path( "c" );
 
   _ = cargo::package( &package_path, false ).expect( "Failed to package a package" );
   let absolute = AbsolutePath::try_from( package_path ).unwrap();
@@ -32,8 +41,7 @@ fn no_changes()
 fn with_changes()
 {
   // Arrange
-  let root_path = std::path::Path::new( env!( "CARGO_MANIFEST_DIR" ) ).join( TEST_MODULE_PATH );
-  let package_path = root_path.join( "c" );
+  let package_path = package_path( "c" );
 
   let temp = assert_fs::TempDir::new().unwrap();
   temp.copy_from( &package_path, &[ "**" ] ).unwrap();


### PR DESCRIPTION
Refactored error handling across multiple modules to be more specific and informative, mainly replacing `anyhow!` with custom and thoughtful error types like `ManifestError` and `CrateDirError`. Also included some minor edits to the test files. Updated the README with more detailed usage scenarios for the tool.